### PR TITLE
Simple fix for potential integer overflow in int array initialization

### DIFF
--- a/util-core/src/main/java/com/indeed/util/core/datastruct/IteratorMultiHeap.java
+++ b/util-core/src/main/java/com/indeed/util/core/datastruct/IteratorMultiHeap.java
@@ -28,7 +28,7 @@ public abstract class IteratorMultiHeap<T> {
     protected IteratorMultiHeap(int capacity, Class<T> tClass) {
         this.elements = (T[])Array.newInstance(tClass, capacity);
         size = 0;
-        candidates = new int[(capacity+1)/2];
+        candidates = new int[capacity/2 + (capacity % 2)];
         nextCandidates = new int[candidates.length];
         minIndexes = new int[capacity];
         min = (T[])Array.newInstance(tClass, capacity);


### PR DESCRIPTION
(capacity+1)/2 can overflow if capacity is Integer.MAX_VALUE which is a legitimate usecase, albeit probably extremely rare. A simple solution is to replace the expression with (capacity/2) + (capacity%2) which has the same end result and is correct for Integer.MAX_VALUE capacity input
