### PR TITLE
Removes Netflix from the OSSLifecycle badge txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # indeedeng/util
 
-![NetflixOSS Lifecycle](https://img.shields.io/osslifecycle/indeedeng/util.svg)
+![OSS Lifecycle](https://img.shields.io/osslifecycle/indeedeng/util.svg)
 
 ## [util-core](https://github.com/indeedeng/util/tree/master/util-core)
 


### PR DESCRIPTION
Fixes an erroneous cut-and-paste error from shields.io, which referenced Netflix in the OSSLifecycle badge alternate text.