### PR TITLE
Fix for issue #20 (dependencies to Guava 16.0.1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-.classpath
+**/.classpath/
 **/.settings/
 .project
 *.iml

--- a/io/src/main/java/com/indeed/util/io/Files.java
+++ b/io/src/main/java/com/indeed/util/io/Files.java
@@ -323,8 +323,7 @@ public class Files {
     }
 
     public static long computeFileChecksum(@Nonnull final File file, @Nonnull final Checksum checksum) throws IOException {
-        return ByteStreams.hash(com.google.common.io.Files.newInputStreamSupplier(file), Hashing.crc32())
-            .padToLong();
+        return com.google.common.io.Files.asByteSource(file).hash(Hashing.crc32()).padToLong();
     }
 
     /**

--- a/urlparsing/src/test/java/com/indeed/util/urlparsing/benchmark/NumberParsingBenchmark.java
+++ b/urlparsing/src/test/java/com/indeed/util/urlparsing/benchmark/NumberParsingBenchmark.java
@@ -67,7 +67,7 @@ public class NumberParsingBenchmark {
 
     public static void doNumberParsingBenchMark(final CharSource intData, final CharSource floatData, final Stopwatch stopwatchA, final Stopwatch stopwatchB, final NumberParser numberParser) throws IOException {
 
-        final Integer numInts = CharStreams.readLines(intData, new LineProcessor<Integer>() {
+        final Integer numInts = intData.readLines(new LineProcessor<Integer>() {
             private int count;
 
             @Override
@@ -86,7 +86,7 @@ public class NumberParsingBenchmark {
             }
         });
 
-        final Integer numFloats = CharStreams.readLines(floatData, new LineProcessor<Integer>() {
+        final Integer numFloats = floatData.readLines(new LineProcessor<Integer>() {
             private int count;
 
             @Override


### PR DESCRIPTION
Here is a fix for #20, to allow upgrading Guava to later versions (and specifically at least to 18.0), without requiring newer version. Tests pass as before, both with existing Guava version (16) and bit newer (18).

Brief testing suggests that code is now compatible all the way up to and including 25.x; 26.0 is the next breakage point due to removal of `CharMatcher.WHITESPACE`.
