### PR TITLE
Fix #22 by changing parent from `oss-parent` to `common-parent`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,8 +3,8 @@
 
     <parent>
         <groupId>com.indeed</groupId>
-        <artifactId>oss-parent</artifactId>
-        <version>19</version>
+        <artifactId>common-parent</artifactId>
+        <version>20</version>
     </parent>
 
     <groupId>com.indeed</groupId>


### PR DESCRIPTION
So: publishing (from internal Gitlab) failed; warning said that expected parent pom is `common-parent`, not (deprecated) `oss-parent`. New version of `oss-parent` as well, just published (to include newer Jackson 2.x version default).
