### PR TITLE
Fix javadoc problems that fail javadoc generation (and thereby publishing)

### DIFF
--- a/compress/src/main/java/com/indeed/util/compress/BlockCompressorStream.java
+++ b/compress/src/main/java/com/indeed/util/compress/BlockCompressorStream.java
@@ -22,13 +22,13 @@ import java.io.IOException;
 import java.io.OutputStream;
 
 /**
- * A {@link org.apache.hadoop.io.compress.CompressorStream} which works
+ * A {@link CompressorStream} which works
  * with 'block-based' based compression algorithms, as opposed to 
  * 'stream-based' compression algorithms.
  *
  * It should be noted that this wrapper does not guarantee that blocks will
  * be sized for the compressor. If the
- * {@link org.apache.hadoop.io.compress.Compressor} requires buffering to
+ * {@link Compressor} requires buffering to
  * effect meaningful compression, it is responsible for it.
  */
 public class BlockCompressorStream extends CompressorStream {

--- a/compress/src/main/java/com/indeed/util/compress/BlockDecompressorStream.java
+++ b/compress/src/main/java/com/indeed/util/compress/BlockDecompressorStream.java
@@ -23,10 +23,9 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /**
- * A {@link org.apache.hadoop.io.compress.DecompressorStream} which works
+ * A {@link DecompressorStream} which works
  * with 'block-based' based compression algorithms, as opposed to 
  * 'stream-based' compression algorithms.
- *  
  */
 public class BlockDecompressorStream extends DecompressorStream {
   private int originalBlockSize = 0;

--- a/compress/src/main/java/com/indeed/util/compress/SnappyCodec.java
+++ b/compress/src/main/java/com/indeed/util/compress/SnappyCodec.java
@@ -31,7 +31,7 @@ import java.io.OutputStream;
 public class SnappyCodec implements CompressionCodec {
 
   /**
-   * Are the native snappy libraries loaded & initialized?
+   * Are the native snappy libraries loaded &amp; initialized?
    */
   public static void checkNativeCodeLoaded() {
       if (!SnappyCompressor.isNativeCodeLoaded()) {

--- a/compress/src/main/java/com/indeed/util/compress/zlib/ZlibCompressor.java
+++ b/compress/src/main/java/com/indeed/util/compress/zlib/ZlibCompressor.java
@@ -354,7 +354,7 @@ public class ZlibCompressor implements Compressor {
   }
 
   /**
-   * Returns the total number of uncompressed bytes input so far.</p>
+   * Returns the total number of uncompressed bytes input so far.
    *
    * @return the total (non-negative) number of uncompressed bytes input so far
    */

--- a/compress/src/main/java/com/indeed/util/compress/zlib/ZlibDecompressor.java
+++ b/compress/src/main/java/com/indeed/util/compress/zlib/ZlibDecompressor.java
@@ -239,7 +239,7 @@ public class ZlibDecompressor implements Decompressor {
   }
 
   /**
-   * Returns the total number of compressed bytes input so far.</p>
+   * Returns the total number of compressed bytes input so far.
    *
    * @return the total (non-negative) number of compressed bytes input so far
    */
@@ -251,7 +251,7 @@ public class ZlibDecompressor implements Decompressor {
   /**
    * Returns the number of bytes remaining in the input buffers; normally
    * called when finished() is true to determine amount of post-gzip-stream
-   * data.</p>
+   * data.
    *
    * @return the total (non-negative) number of unprocessed bytes in input
    */
@@ -261,7 +261,7 @@ public class ZlibDecompressor implements Decompressor {
   }
 
   /**
-   * Resets everything including the input buffers (user and direct).</p>
+   * Resets everything including the input buffers (user and direct).
    */
   public synchronized void reset() {
     checkStream();

--- a/io/src/main/java/com/indeed/util/io/Directories.java
+++ b/io/src/main/java/com/indeed/util/io/Directories.java
@@ -38,9 +38,9 @@ public final class Directories {
 
     /**
      * Convenience method to return all paths in a SMALL directory.
-     * <p/>
+     * <p>
      * DO NOT USE THIS TO TRAVERSE LARGE (multi-thousand inode) DIRECTORIES!
-     * <p/>
+     * <p>
      * For starters you shouldn't be making directories that big at all, but if you did please use
      * {@link Files#newDirectoryStream(Path)} directly in your code.
      *

--- a/urlparsing/src/main/java/com/indeed/util/urlparsing/ParseUtils.java
+++ b/urlparsing/src/main/java/com/indeed/util/urlparsing/ParseUtils.java
@@ -26,7 +26,7 @@ public final class ParseUtils {
      * Parses out an int value from the provided string, equivalent to Integer.parseInt(s.substring(start, end)),
      * but has significantly less overhead, no object creation and later garbage collection required.
      *
-     * @throws {@link NumberFormatException} if it encounters any character that is not [-0-9].
+     * @throws NumberFormatException if it encounters any character that is not [-0-9].
      */
     public static int parseSignedInt(CharSequence s, final int start, final int end) throws NumberFormatException {
         if (s.charAt(start) == '-') {
@@ -60,7 +60,7 @@ public final class ParseUtils {
      * Parses out a long value from the provided string, equivalent to Long.parseLong(s.substring(start, end)),
      * but has significantly less overhead, no object creation and later garbage collection required
      *
-     * @throws {@link NumberFormatException} if it encounters any character that is not [-0-9].
+     * @throws NumberFormatException if it encounters any character that is not [-0-9].
      */
     public static long parseSignedLong(CharSequence s, final int start, final int end) throws NumberFormatException {
         if (s.charAt(start) == '-') {
@@ -75,7 +75,7 @@ public final class ParseUtils {
      * Parses out a long value from the provided string, equivalent to Long.parseLong(s.substring(start, end)),
      * but has significantly less overhead, no object creation and later garbage collection required
      *
-     * @throws {@link NumberFormatException} if it encounters any character that is not [0-9].
+     * @throws NumberFormatException if it encounters any character that is not [0-9].
      */
     public static long parseUnsignedLong(CharSequence s, final int start, final int end) throws NumberFormatException {
         long ret = 0;
@@ -97,7 +97,7 @@ public final class ParseUtils {
      * Parses out a float value from the provided string, more specialized than Float.parseFloat(s.substring(start, end))
      * but has significantly less overhead, no object creation and later garbage collection required
      * Does not support parsing the strings "NaN", "Infinity","-Infinity" and HexFloatingPointLiterals
-     * @throws {@link NumberFormatException} if the input doesn't correspond to a float.
+     * @throws NumberFormatException if the input doesn't correspond to a float.
      */
     public static float parseFloat(String s, final int start, final int end) throws NumberFormatException {
         int i = start;

--- a/urlparsing/src/main/java/com/indeed/util/urlparsing/QueryStringParser.java
+++ b/urlparsing/src/main/java/com/indeed/util/urlparsing/QueryStringParser.java
@@ -9,7 +9,7 @@ package com.indeed.util.urlparsing;
 
 public class QueryStringParser {
     /**
-     * @param queryString The raw urlParams string (e.g. "key1=value1&key2=value2&key3=value3&key4=value4")
+     * @param queryString The raw urlParams string (e.g. {@code "key1=value1&key2=value2&key3=value3&key4=value4"})
      * @param callback Callback which is called for each key/value pair
      * @param storage Storage object, passed to each callback call
      */
@@ -18,12 +18,12 @@ public class QueryStringParser {
     }
 
     /**
-     * @param queryString The raw urlParams string (e.g. "key1=value1&key2=value2&key3=value3&key4=value4")
+     * @param queryString The raw urlParams string (e.g. {@code "key1=value1&key2=value2&key3=value3&key4=value4"})
      * @param callback Callback which is called for each key/value pair
      * @param storage Storage object, passed to each callback call
      * @param qsStart index into queryString param where queryString actually starts
      * @param qsEnd index into queryString param where queryString actually ends
-     * @param pairDelim String delimeter that occurs between keyvalue pairs, e.g. "&"
+     * @param pairDelim String delimeter that occurs between keyvalue pairs, e.g. {@code "&"}
      * @param kvDelim String delimeted that occurs between a key and its value, e.g. "="
      */
     public static <T> void parseQueryString(String queryString, QueryStringParserCallback<T> callback, T storage, int qsStart, int qsEnd, String pairDelim, String kvDelim) {

--- a/urlparsing/src/main/java/com/indeed/util/urlparsing/QueryStringParserCallback.java
+++ b/urlparsing/src/main/java/com/indeed/util/urlparsing/QueryStringParserCallback.java
@@ -8,7 +8,7 @@ public interface QueryStringParserCallback<T> {
     /**
      * This callback is used by URLParamsParser and is called for each key/value pair in the urlParams String
      *
-     * @param queryString The raw queryString (e.g. "key1=value1&key2=value2&key3=value3&key4=value4")
+     * @param queryString The raw queryString (e.g. {@code "key1=value1&key2=value2&key3=value3&key4=value4")}
      * @param keyStart Index into queryString where the key in this key/value begins (inclusive)
      * @param keyEnd Index into queryString where the key in this key/value ends (exclusive)
      * @param valueStart Index into queryString where the value in this key/value begins (inclusive)


### PR DESCRIPTION
So, attempt to publish new version failed on Javadoc generation: something in new settings (due to changed parent pom?) caused JDK 8 default strict checks to be used, and there were a few places where formerly acceptable (if wrong) HTML now triggers error.
