### PR TITLE
Update log4j from 1.x to 2.x. 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,10 @@ allprojects {
         }
 
         def versions = [
-                'log4j:log4j': '1.2.17',
+                'org.apache.logging.log4j:log4j-core': '2.13.3',
+                'org.apache.logging.log4j:log4j-api': '2.13.3',
+                // TODO: remove once downstream dependents are updated
+                'log4j:log4j': '1.2.7', 
                 'junit:junit': '4.8.2',
                 'com.google.guava:guava': '19.0',
                 'com.google.code.findbugs:jsr305': '1.3.9',
@@ -15,6 +18,7 @@ allprojects {
                 'commons-lang:commons-lang': '2.6',
                 'org.hamcrest:hamcrest-core': '2.2'
         ];
+
         ext['library'] = {
             return it + ':' + versions[it]
         }

--- a/compress/build.gradle
+++ b/compress/build.gradle
@@ -6,7 +6,8 @@ ext['indeed.publish.name'] = 'util-compress'
 
 dependencies {
     compile project(':util-core')
-    compile library('log4j:log4j')
+    compile library('org.apache.logging.log4j:log4j-core')
+    compile library('org.apache.logging.log4j:log4j-api')
 
     testCompile library('junit:junit')
 }

--- a/compress/src/main/java/com/indeed/util/compress/NativeCodeLoader.java
+++ b/compress/src/main/java/com/indeed/util/compress/NativeCodeLoader.java
@@ -1,13 +1,14 @@
 package com.indeed.util.compress;
 
 import com.indeed.util.core.NativeLibraryUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * @author jplaisance
  */
 public final class NativeCodeLoader {
-    private static final Logger log = Logger.getLogger(NativeCodeLoader.class);
+    private static final Logger log = LogManager.getLogger(NativeCodeLoader.class);
 
     static boolean nativeCodeLoaded = false;
 

--- a/compress/src/main/java/com/indeed/util/compress/snappy/SnappyCompressor.java
+++ b/compress/src/main/java/com/indeed/util/compress/snappy/SnappyCompressor.java
@@ -20,7 +20,8 @@ package com.indeed.util.compress.snappy;
 
 import com.indeed.util.compress.Compressor;
 import com.indeed.util.compress.NativeCodeLoader;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.IOException;
 import java.nio.Buffer;
@@ -31,7 +32,7 @@ import java.nio.ByteBuffer;
  * http://code.google.com/p/snappy/
  */
 public class SnappyCompressor implements Compressor {
-  private static final Logger LOG = Logger.getLogger(SnappyCompressor.class);
+  private static final Logger LOG = LogManager.getLogger(SnappyCompressor.class);
   private static final int DEFAULT_DIRECT_BUFFER_SIZE = 64 * 1024;
 
   // HACK - Use this as a global lock in the JNI layer

--- a/compress/src/main/java/com/indeed/util/compress/snappy/SnappyDecompressor.java
+++ b/compress/src/main/java/com/indeed/util/compress/snappy/SnappyDecompressor.java
@@ -20,7 +20,8 @@ package com.indeed.util.compress.snappy;
 
 import com.indeed.util.compress.Decompressor;
 import com.indeed.util.compress.NativeCodeLoader;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.IOException;
 import java.nio.Buffer;
@@ -31,7 +32,7 @@ import java.nio.ByteBuffer;
  * http://code.google.com/p/snappy/
  */
 public class SnappyDecompressor implements Decompressor {
-  private static final Logger LOG = Logger.getLogger(SnappyCompressor.class);
+  private static final Logger LOG = LogManager.getLogger(SnappyCompressor.class);
   private static final int DEFAULT_DIRECT_BUFFER_SIZE = 64 * 1024;
 
   // HACK - Use this as a global lock in the JNI layer

--- a/compress/src/main/java/com/indeed/util/compress/zlib/ZlibCompressor.java
+++ b/compress/src/main/java/com/indeed/util/compress/zlib/ZlibCompressor.java
@@ -20,7 +20,8 @@ package com.indeed.util.compress.zlib;
 
 import com.indeed.util.compress.Compressor;
 import com.indeed.util.compress.NativeCodeLoader;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.IOException;
 import java.nio.Buffer;
@@ -34,7 +35,7 @@ import java.nio.ByteBuffer;
  */
 public class ZlibCompressor implements Compressor {
 
-  private static final Logger LOG = Logger.getLogger(ZlibCompressor.class);
+  private static final Logger LOG = LogManager.getLogger(ZlibCompressor.class);
 
   private static final int DEFAULT_DIRECT_BUFFER_SIZE = 64*1024;
 

--- a/compress/src/test/java/com/indeed/util/compress/TestCodecs.java
+++ b/compress/src/test/java/com/indeed/util/compress/TestCodecs.java
@@ -3,7 +3,8 @@ package com.indeed.util.compress;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.Files;
 import junit.framework.TestCase;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -17,7 +18,7 @@ import java.util.Arrays;
  * @author jplaisance
  */
 public final class TestCodecs extends TestCase {
-    private static final Logger log = Logger.getLogger(TestCodecs.class);
+    private static final Logger log = LogManager.getLogger(TestCodecs.class);
 
     public static void testGzip() throws IOException {
 /*        GzipCodec codec = new GzipCodec();

--- a/io/build.gradle
+++ b/io/build.gradle
@@ -8,7 +8,8 @@ dependencies {
     compile project(':serialization')
     compile project(':util-core')
     compile library('com.google.guava:guava')
-    compile library('log4j:log4j')
+    compile library('org.apache.logging.log4j:log4j-core')
+    compile library('org.apache.logging.log4j:log4j-api')
 
     compileOnly library('com.google.code.findbugs:jsr305')
 

--- a/io/src/main/java/com/indeed/util/io/Files.java
+++ b/io/src/main/java/com/indeed/util/io/Files.java
@@ -7,7 +7,8 @@ import com.google.common.base.Supplier;
 import com.google.common.hash.Hashing;
 import com.google.common.io.ByteStreams;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import javax.annotation.Nonnull;
 
@@ -28,7 +29,7 @@ import java.util.zip.Checksum;
 public class Files {
     // you may wish to use this particular logger sparingly, as many times it can be more helpful
     // if you log stuff to a more specific (context-specific) logger than something in common-util
-    private static final Logger LOGGER = Logger.getLogger(Files.class);
+    private static final Logger LOGGER = LogManager.getLogger(Files.class);
 
     private Files() {
     }

--- a/io/src/main/java/com/indeed/util/io/SafeFiles.java
+++ b/io/src/main/java/com/indeed/util/io/SafeFiles.java
@@ -4,7 +4,8 @@ package com.indeed.util.io;
 import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
 import com.indeed.util.core.io.Closeables2;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import javax.annotation.Nonnegative;
 import javax.annotation.Nonnull;
@@ -38,7 +39,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  */
 @ParametersAreNonnullByDefault
 public final class SafeFiles {
-    private static final Logger LOG = Logger.getLogger(SafeFiles.class);
+    private static final Logger LOG = LogManager.getLogger(SafeFiles.class);
 
     /**
      * Perform an atomic rename of oldName -&gt; newName and fsync the containing directory.

--- a/io/src/main/java/com/indeed/util/io/UnsafeByteArrayOutputStream.java
+++ b/io/src/main/java/com/indeed/util/io/UnsafeByteArrayOutputStream.java
@@ -1,6 +1,7 @@
 package com.indeed.util.io;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.OutputStream;
 import java.util.Arrays;
@@ -9,7 +10,7 @@ import java.util.Arrays;
  * @author jplaisance
  */
 public final class UnsafeByteArrayOutputStream extends OutputStream {
-    private static final Logger log = Logger.getLogger(UnsafeByteArrayOutputStream.class);
+    private static final Logger log = LogManager.getLogger(UnsafeByteArrayOutputStream.class);
     
     private byte[] buf;
     private int count = 0;

--- a/io/src/main/java/com/indeed/util/io/VIntUtils.java
+++ b/io/src/main/java/com/indeed/util/io/VIntUtils.java
@@ -1,6 +1,7 @@
 package com.indeed.util.io;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -13,7 +14,7 @@ import java.io.OutputStream;
  */
 public final class VIntUtils {
 
-    private static final Logger log = Logger.getLogger(VIntUtils.class);
+    private static final Logger log = LogManager.getLogger(VIntUtils.class);
 
     public static int writeVInt(OutputStream out, int i) throws IOException {
         if (i < 0) {

--- a/io/src/test/java/com/indeed/util/io/DirectoriesTest.java
+++ b/io/src/test/java/com/indeed/util/io/DirectoriesTest.java
@@ -1,9 +1,14 @@
 // Copyright 2015 Indeed
 package com.indeed.util.io;
 
-import org.apache.log4j.BasicConfigurator;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
+import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -16,6 +21,8 @@ import java.io.IOException;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.List;
+
+import static org.apache.logging.log4j.core.appender.ConsoleAppender.Target;
 
 /**
  * @author rboyer
@@ -81,9 +88,19 @@ public class DirectoriesTest {
 
     @BeforeClass
     public static void initClass() {
-        BasicConfigurator.resetConfiguration();
-        BasicConfigurator.configure();
-        Logger.getRootLogger().setLevel(Level.WARN);
-        Logger.getLogger("com.indeed").setLevel(Level.DEBUG);
+        ConfigurationBuilder<BuiltConfiguration> builder = ConfigurationBuilderFactory.newConfigurationBuilder();
+        final Configuration config = builder.setStatusLevel(Level.WARN)
+                                      .setConfigurationName("Indeed Logging")
+                                      .add(builder.newAppender("stderr", "Console")
+                                                  .addAttribute("target", Target.SYSTEM_ERR))
+                                      .add(builder.newAsyncLogger("com.indeed", Level.DEBUG)
+                                                  .add(builder.newAppenderRef("stderr"))
+                                                  .addAttribute("addivity", false))
+                                      .add(builder.newAsyncRootLogger(Level.WARN)
+                                                  .add(builder.newAppenderRef("stderr"))
+                                                  .addAttribute("additivity", false))
+                                      .build();
+        Configurator.initialize(builder.build());
+
     }
 }

--- a/io/src/test/java/com/indeed/util/io/SafeFilesTest.java
+++ b/io/src/test/java/com/indeed/util/io/SafeFilesTest.java
@@ -3,9 +3,14 @@ package com.indeed.util.io;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Throwables;
-import org.apache.log4j.BasicConfigurator;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
+import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Level;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -21,6 +26,8 @@ import java.nio.file.Files;
 import java.nio.file.attribute.PosixFilePermission;
 import java.nio.file.attribute.PosixFilePermissions;
 import java.util.Set;
+
+import static org.apache.logging.log4j.core.appender.ConsoleAppender.Target;
 
 /**
  * @author rboyer
@@ -264,9 +271,18 @@ public class SafeFilesTest {
 
     @BeforeClass
     public static void initClass() {
-        BasicConfigurator.resetConfiguration();
-        BasicConfigurator.configure();
-        Logger.getRootLogger().setLevel(Level.WARN);
-        Logger.getLogger("com.indeed").setLevel(Level.DEBUG);
+        ConfigurationBuilder<BuiltConfiguration> builder = ConfigurationBuilderFactory.newConfigurationBuilder();
+        final Configuration config = builder.setStatusLevel(Level.WARN)
+                                      .setConfigurationName("Indeed Logging")
+                                      .add(builder.newAppender("stderr", "Console")
+                                                  .addAttribute("target", Target.SYSTEM_ERR))
+                                      .add(builder.newAsyncLogger("com.indeed", Level.DEBUG)
+                                                  .add(builder.newAppenderRef("stderr"))
+                                                  .addAttribute("addivity", false))
+                                      .add(builder.newAsyncRootLogger(Level.WARN)
+                                                  .add(builder.newAppenderRef("stderr"))
+                                                  .addAttribute("additivity", false))
+                                      .build();
+        Configurator.initialize(builder.build());
     }
 }

--- a/io/src/test/java/com/indeed/util/io/TestVIntUtils.java
+++ b/io/src/test/java/com/indeed/util/io/TestVIntUtils.java
@@ -1,7 +1,8 @@
 package com.indeed.util.io;
 
 import junit.framework.TestCase;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -11,7 +12,7 @@ import java.io.ByteArrayOutputStream;
  */
 public final class TestVIntUtils extends TestCase {
 
-    private static final Logger log = Logger.getLogger(TestVIntUtils.class);
+    private static final Logger log = LogManager.getLogger(TestVIntUtils.class);
 
     int[] ints = new int[]{1, -1, 0, Integer.MAX_VALUE, Integer.MIN_VALUE, 63, -64, 64, -65};
 

--- a/mmap/build.gradle
+++ b/mmap/build.gradle
@@ -6,7 +6,8 @@ ext['indeed.publish.name'] = 'util-mmap'
 
 dependencies {
     compile library('com.google.guava:guava')
-    compile library('log4j:log4j')
+    compile library('org.apache.logging.log4j:log4j-core')
+    compile library('org.apache.logging.log4j:log4j-api')
 
     testCompile library('junit:junit')
 }

--- a/mmap/src/main/java/com/indeed/util/mmap/ByteArray.java
+++ b/mmap/src/main/java/com/indeed/util/mmap/ByteArray.java
@@ -1,12 +1,13 @@
 package com.indeed.util.mmap;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * @author jplaisance
  */
 public final class ByteArray {
-    private static final Logger log = Logger.getLogger(ByteArray.class);
+    private static final Logger log = LogManager.getLogger(ByteArray.class);
     
     private final Memory buffer;
     private final long length;

--- a/mmap/src/main/java/com/indeed/util/mmap/CharArray.java
+++ b/mmap/src/main/java/com/indeed/util/mmap/CharArray.java
@@ -1,12 +1,13 @@
 package com.indeed.util.mmap;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * @author jplaisance
  */
 public final class CharArray {
-    private static final Logger log = Logger.getLogger(CharArray.class);
+    private static final Logger log = LogManager.getLogger(CharArray.class);
 
     private static final long TYPE_SIZE = 2;
 

--- a/mmap/src/main/java/com/indeed/util/mmap/DirectMemory.java
+++ b/mmap/src/main/java/com/indeed/util/mmap/DirectMemory.java
@@ -1,6 +1,7 @@
 package com.indeed.util.mmap;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -9,7 +10,7 @@ import java.nio.ByteOrder;
  * @author jplaisance
  */
 public final class DirectMemory extends AbstractMemory {
-    private static final Logger log = Logger.getLogger(DirectMemory.class);
+    private static final Logger log = LogManager.getLogger(DirectMemory.class);
     private static final boolean debug = true;
 
     private final ByteOrder order;

--- a/mmap/src/main/java/com/indeed/util/mmap/DoubleArray.java
+++ b/mmap/src/main/java/com/indeed/util/mmap/DoubleArray.java
@@ -1,12 +1,13 @@
 package com.indeed.util.mmap;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * @author jplaisance
  */
 public final class DoubleArray {
-    private static final Logger log = Logger.getLogger(DoubleArray.class);
+    private static final Logger log = LogManager.getLogger(DoubleArray.class);
 
     private static final long TYPE_SIZE = 8;
 

--- a/mmap/src/main/java/com/indeed/util/mmap/DynamicMMapBufferDataOutputStream.java
+++ b/mmap/src/main/java/com/indeed/util/mmap/DynamicMMapBufferDataOutputStream.java
@@ -1,6 +1,7 @@
 package com.indeed.util.mmap;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataOutput;
 import java.io.File;
@@ -16,7 +17,7 @@ import java.util.List;
  */
 public final class DynamicMMapBufferDataOutputStream extends OutputStream implements DataOutput {
 
-    private static final Logger log = Logger.getLogger(DynamicMMapBufferDataOutputStream.class);
+    private static final Logger log = LogManager.getLogger(DynamicMMapBufferDataOutputStream.class);
 
     private MMapBuffer buffer;
 

--- a/mmap/src/main/java/com/indeed/util/mmap/FloatArray.java
+++ b/mmap/src/main/java/com/indeed/util/mmap/FloatArray.java
@@ -1,12 +1,13 @@
 package com.indeed.util.mmap;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * @author jplaisance
  */
 public final class FloatArray {
-    private static final Logger log = Logger.getLogger(FloatArray.class);
+    private static final Logger log = LogManager.getLogger(FloatArray.class);
 
     private static final long TYPE_SIZE = 4;
 

--- a/mmap/src/main/java/com/indeed/util/mmap/HeapBuffer.java
+++ b/mmap/src/main/java/com/indeed/util/mmap/HeapBuffer.java
@@ -1,6 +1,7 @@
 package com.indeed.util.mmap;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.IOException;
 import java.nio.ByteOrder;
@@ -9,7 +10,7 @@ import java.nio.ByteOrder;
  * @author jplaisance
  */
 public final class HeapBuffer implements BufferResource {
-    private static final Logger log = Logger.getLogger(HeapBuffer.class);
+    private static final Logger log = LogManager.getLogger(HeapBuffer.class);
 
     private final HeapMemory memory;
 

--- a/mmap/src/main/java/com/indeed/util/mmap/HeapMemory.java
+++ b/mmap/src/main/java/com/indeed/util/mmap/HeapMemory.java
@@ -1,6 +1,7 @@
 package com.indeed.util.mmap;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
@@ -9,7 +10,7 @@ import java.nio.ByteOrder;
  * @author jplaisance
  */
 public final class HeapMemory extends AbstractMemory {
-    private static final Logger log = Logger.getLogger(HeapMemory.class);
+    private static final Logger log = LogManager.getLogger(HeapMemory.class);
     private static final boolean debug = true;
 
     private final byte[] data;

--- a/mmap/src/main/java/com/indeed/util/mmap/IntArray.java
+++ b/mmap/src/main/java/com/indeed/util/mmap/IntArray.java
@@ -1,12 +1,13 @@
 package com.indeed.util.mmap;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * @author jplaisance
  */
 public final class IntArray {
-    private static final Logger log = Logger.getLogger(IntArray.class);
+    private static final Logger log = LogManager.getLogger(IntArray.class);
 
     private static final long TYPE_SIZE = 4;
 

--- a/mmap/src/main/java/com/indeed/util/mmap/LoadIndeedMMap.java
+++ b/mmap/src/main/java/com/indeed/util/mmap/LoadIndeedMMap.java
@@ -1,7 +1,8 @@
 package com.indeed.util.mmap;
 
 import com.google.common.io.ByteStreams;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -13,7 +14,7 @@ import java.io.OutputStream;
  * @author jplaisance
  */
 public final class LoadIndeedMMap {
-    private static final Logger log = Logger.getLogger(LoadIndeedMMap.class);
+    private static final Logger log = LogManager.getLogger(LoadIndeedMMap.class);
 
     private static boolean loaded = false;
 

--- a/mmap/src/main/java/com/indeed/util/mmap/LongArray.java
+++ b/mmap/src/main/java/com/indeed/util/mmap/LongArray.java
@@ -1,12 +1,13 @@
 package com.indeed.util.mmap;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * @author jplaisance
  */
 public final class LongArray {
-    private static final Logger log = Logger.getLogger(LongArray.class);
+    private static final Logger log = LogManager.getLogger(LongArray.class);
 
     private static final long TYPE_SIZE = 8;
 

--- a/mmap/src/main/java/com/indeed/util/mmap/MemoryDataInput.java
+++ b/mmap/src/main/java/com/indeed/util/mmap/MemoryDataInput.java
@@ -1,6 +1,7 @@
 package com.indeed.util.mmap;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataInput;
 import java.io.IOException;
@@ -11,7 +12,7 @@ import java.io.IOException;
  */
 public final class MemoryDataInput implements DataInput {
 
-    private static final Logger log = Logger.getLogger(MemoryDataInput.class);
+    private static final Logger log = LogManager.getLogger(MemoryDataInput.class);
     
     private final Memory memory;
 

--- a/mmap/src/main/java/com/indeed/util/mmap/MemoryInputStream.java
+++ b/mmap/src/main/java/com/indeed/util/mmap/MemoryInputStream.java
@@ -1,6 +1,7 @@
 package com.indeed.util.mmap;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -9,7 +10,7 @@ import java.io.InputStream;
  * @author jplaisance
  */
 public final class MemoryInputStream extends InputStream {
-    private static final Logger log = Logger.getLogger(MemoryInputStream.class);
+    private static final Logger log = LogManager.getLogger(MemoryInputStream.class);
 
     private final Memory memory;
 

--- a/mmap/src/main/java/com/indeed/util/mmap/MemoryScatteringByteChannel.java
+++ b/mmap/src/main/java/com/indeed/util/mmap/MemoryScatteringByteChannel.java
@@ -1,6 +1,7 @@
 package com.indeed.util.mmap;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -11,7 +12,7 @@ import java.nio.channels.ScatteringByteChannel;
 */
 public final class MemoryScatteringByteChannel implements ScatteringByteChannel {
 
-    private static final Logger log = Logger.getLogger(MemoryScatteringByteChannel.class);
+    private static final Logger log = LogManager.getLogger(MemoryScatteringByteChannel.class);
 
     private boolean closed = false;
 

--- a/mmap/src/main/java/com/indeed/util/mmap/NativeBuffer.java
+++ b/mmap/src/main/java/com/indeed/util/mmap/NativeBuffer.java
@@ -1,7 +1,8 @@
 package com.indeed.util.mmap;
 
 import com.google.common.base.Throwables;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import sun.misc.Unsafe;
 
 import java.io.Closeable;
@@ -17,7 +18,7 @@ import java.nio.ByteOrder;
  * @author jplaisance
  */
 public final class NativeBuffer implements BufferResource {
-    private static final Logger log = Logger.getLogger(NativeBuffer.class);
+    private static final Logger log = LogManager.getLogger(NativeBuffer.class);
 
     private static final Unsafe UNSAFE;
     private static final Field FD_FIELD;

--- a/mmap/src/main/java/com/indeed/util/mmap/NativeEndianDirectDataAccess.java
+++ b/mmap/src/main/java/com/indeed/util/mmap/NativeEndianDirectDataAccess.java
@@ -1,6 +1,7 @@
 package com.indeed.util.mmap;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import sun.misc.Unsafe;
 
 import java.lang.reflect.Field;
@@ -9,7 +10,7 @@ import java.lang.reflect.Field;
  * @author jplaisance
  */
 final class NativeEndianDirectDataAccess implements DirectDataAccess {
-    private static final Logger log = Logger.getLogger(NativeEndianDirectDataAccess.class);
+    private static final Logger log = LogManager.getLogger(NativeEndianDirectDataAccess.class);
 
     private static final Unsafe UNSAFE;
     private static final NativeEndianDirectDataAccess instance = new NativeEndianDirectDataAccess();

--- a/mmap/src/main/java/com/indeed/util/mmap/NativeEndianHeapDataAccess.java
+++ b/mmap/src/main/java/com/indeed/util/mmap/NativeEndianHeapDataAccess.java
@@ -1,6 +1,7 @@
 package com.indeed.util.mmap;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import sun.misc.Unsafe;
 
 import java.lang.reflect.Field;
@@ -10,7 +11,7 @@ import java.lang.reflect.Field;
  * @author jplaisance
  */
 final class NativeEndianHeapDataAccess implements HeapDataAccess {
-    private static final Logger log = Logger.getLogger(NativeEndianHeapDataAccess.class);
+    private static final Logger log = LogManager.getLogger(NativeEndianHeapDataAccess.class);
 
     private static final Unsafe UNSAFE;
     private static final long BYTE_ARRAY_BASE_OFFSET;

--- a/mmap/src/main/java/com/indeed/util/mmap/NativeFileUtils.java
+++ b/mmap/src/main/java/com/indeed/util/mmap/NativeFileUtils.java
@@ -1,6 +1,7 @@
 package com.indeed.util.mmap;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -11,7 +12,7 @@ import java.io.IOException;
  */
 public final class NativeFileUtils {
 
-    private static final Logger log = Logger.getLogger(NativeFileUtils.class);
+    private static final Logger log = LogManager.getLogger(NativeFileUtils.class);
 
     public static long du(String path) throws IOException {
 

--- a/mmap/src/main/java/com/indeed/util/mmap/NativeMemoryUtils.java
+++ b/mmap/src/main/java/com/indeed/util/mmap/NativeMemoryUtils.java
@@ -1,6 +1,7 @@
 package com.indeed.util.mmap;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.nio.ByteBuffer;
 
@@ -8,7 +9,7 @@ import java.nio.ByteBuffer;
  * @author jplaisance
  */
 final class NativeMemoryUtils {
-    private static final Logger log = Logger.getLogger(NativeMemoryUtils.class);
+    private static final Logger log = LogManager.getLogger(NativeMemoryUtils.class);
 
     static {
         LoadIndeedMMap.loadLibrary();

--- a/mmap/src/main/java/com/indeed/util/mmap/ReverseEndianDirectDataAccess.java
+++ b/mmap/src/main/java/com/indeed/util/mmap/ReverseEndianDirectDataAccess.java
@@ -1,12 +1,13 @@
 package com.indeed.util.mmap;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * @author jplaisance
  */
 final class ReverseEndianDirectDataAccess implements DirectDataAccess {
-    private static final Logger log = Logger.getLogger(ReverseEndianDirectDataAccess.class);
+    private static final Logger log = LogManager.getLogger(ReverseEndianDirectDataAccess.class);
 
     private static final NativeEndianDirectDataAccess delegate = NativeEndianDirectDataAccess.getInstance();
 

--- a/mmap/src/main/java/com/indeed/util/mmap/ReverseEndianHeapDataAccess.java
+++ b/mmap/src/main/java/com/indeed/util/mmap/ReverseEndianHeapDataAccess.java
@@ -1,12 +1,13 @@
 package com.indeed.util.mmap;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * @author jplaisance
  */
 final class ReverseEndianHeapDataAccess implements HeapDataAccess {
-    private static final Logger log = Logger.getLogger(ReverseEndianHeapDataAccess.class);
+    private static final Logger log = LogManager.getLogger(ReverseEndianHeapDataAccess.class);
     private static final ReverseEndianHeapDataAccess instance = new ReverseEndianHeapDataAccess();
 
     private static final NativeEndianHeapDataAccess delegate = NativeEndianHeapDataAccess.getInstance();

--- a/mmap/src/main/java/com/indeed/util/mmap/ShortArray.java
+++ b/mmap/src/main/java/com/indeed/util/mmap/ShortArray.java
@@ -1,12 +1,13 @@
 package com.indeed.util.mmap;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * @author jplaisance
  */
 public final class ShortArray {
-    private static final Logger log = Logger.getLogger(ShortArray.class);
+    private static final Logger log = LogManager.getLogger(ShortArray.class);
 
     private static final long TYPE_SIZE = 2;
 

--- a/mmap/src/main/java/com/indeed/util/mmap/Stat.java
+++ b/mmap/src/main/java/com/indeed/util/mmap/Stat.java
@@ -2,7 +2,8 @@ package com.indeed.util.mmap;
 
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.File;
 import java.io.FileDescriptor;
@@ -16,7 +17,7 @@ import java.nio.ByteOrder;
  */
 public final class Stat {
 
-    private static final Logger log = Logger.getLogger(Stat.class);
+    private static final Logger log = LogManager.getLogger(Stat.class);
 
     private static final Field fdField;
 

--- a/mmap/src/main/java/com/indeed/util/mmap/ZeroCopyOutputStream.java
+++ b/mmap/src/main/java/com/indeed/util/mmap/ZeroCopyOutputStream.java
@@ -1,7 +1,8 @@
 package com.indeed.util.mmap;
 
 import com.google.common.io.ByteStreams;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataOutput;
 import java.io.IOException;
@@ -16,7 +17,7 @@ import java.nio.ByteOrder;
  * @author jplaisance
  */
 public final class ZeroCopyOutputStream extends OutputStream implements DataOutput {
-    private static final Logger log = Logger.getLogger(ZeroCopyOutputStream.class);
+    private static final Logger log = LogManager.getLogger(ZeroCopyOutputStream.class);
 
     private NativeBuffer buffer;
     private DirectMemory memory;

--- a/mmap/src/test/java/com/indeed/util/mmap/MemoryInputTest.java
+++ b/mmap/src/test/java/com/indeed/util/mmap/MemoryInputTest.java
@@ -1,7 +1,8 @@
 package com.indeed.util.mmap;
 
 import junit.framework.TestCase;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.File;
 import java.nio.ByteBuffer;
@@ -12,7 +13,7 @@ import java.nio.channels.FileChannel;
  * @author goodwin
  */
 public class MemoryInputTest extends TestCase {
-    private static final Logger log = Logger.getLogger(MemoryInputTest.class);
+    private static final Logger log = LogManager.getLogger(MemoryInputTest.class);
 
     int length = 120000;
 

--- a/mmap/src/test/java/com/indeed/util/mmap/NativeBufferTest.java
+++ b/mmap/src/test/java/com/indeed/util/mmap/NativeBufferTest.java
@@ -1,7 +1,8 @@
 package com.indeed.util.mmap;
 
 import junit.framework.TestCase;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.IOException;
 import java.nio.ByteOrder;
@@ -10,7 +11,7 @@ import java.nio.ByteOrder;
  * @author goodwin
  */
 public class NativeBufferTest extends TestCase {
-    private static final Logger log = Logger.getLogger(NativeBufferTest.class);
+    private static final Logger log = LogManager.getLogger(NativeBufferTest.class);
 
     long length = 10000;
 

--- a/mmap/src/test/java/com/indeed/util/mmap/TestWeirdStuff.java
+++ b/mmap/src/test/java/com/indeed/util/mmap/TestWeirdStuff.java
@@ -3,7 +3,8 @@ package com.indeed.util.mmap;
 import com.google.common.io.Files;
 import com.google.common.io.LittleEndianDataOutputStream;
 import junit.framework.TestCase;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.BufferedOutputStream;
 import java.io.File;
@@ -19,7 +20,7 @@ import java.nio.channels.FileChannel;
  */
 public final class TestWeirdStuff extends TestCase {
 
-    private static final Logger log = Logger.getLogger(TestWeirdStuff.class);
+    private static final Logger log = LogManager.getLogger(TestWeirdStuff.class);
 
     File tmpDir;
 

--- a/serialization/build.gradle
+++ b/serialization/build.gradle
@@ -5,9 +5,10 @@ plugins {
 ext['indeed.publish.name'] = 'util-serialization'
 
 dependencies {
-    compile library('log4j:log4j')
     compile library('commons-lang:commons-lang')
     compile library('com.google.guava:guava')
+    compile library('org.apache.logging.log4j:log4j-core')
+    compile library('org.apache.logging.log4j:log4j-api')
 
     testCompile library('junit:junit')
 }

--- a/serialization/src/main/java/com/indeed/util/serialization/BooleanSerializer.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/BooleanSerializer.java
@@ -1,6 +1,7 @@
 package com.indeed.util.serialization;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -11,7 +12,7 @@ import java.io.IOException;
  */
 public final class BooleanSerializer implements Serializer<Boolean> {
 
-    private static final Logger log = Logger.getLogger(BooleanSerializer.class);
+    private static final Logger log = LogManager.getLogger(BooleanSerializer.class);
 
     @Override
     public void write(final Boolean val, final DataOutput out) throws IOException {

--- a/serialization/src/main/java/com/indeed/util/serialization/BooleanStringifier.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/BooleanStringifier.java
@@ -1,12 +1,13 @@
 package com.indeed.util.serialization;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * @author jplaisance
  */
 public final class BooleanStringifier implements Stringifier<Boolean> {
-    private static final Logger log = Logger.getLogger(BooleanStringifier.class);
+    private static final Logger log = LogManager.getLogger(BooleanStringifier.class);
 
     @Override
     public String toString(Boolean aBoolean) {

--- a/serialization/src/main/java/com/indeed/util/serialization/ByteSerializer.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/ByteSerializer.java
@@ -1,6 +1,7 @@
 package com.indeed.util.serialization;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -11,7 +12,7 @@ import java.io.IOException;
  */
 public final class ByteSerializer implements Serializer<Byte> {
 
-    private static final Logger log = Logger.getLogger(ByteSerializer.class);
+    private static final Logger log = LogManager.getLogger(ByteSerializer.class);
 
     @Override
     public void write(final Byte val, final DataOutput out) throws IOException {

--- a/serialization/src/main/java/com/indeed/util/serialization/ByteStringifier.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/ByteStringifier.java
@@ -1,12 +1,13 @@
 package com.indeed.util.serialization;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * @author jplaisance
  */
 public final class ByteStringifier implements Stringifier<Byte> {
-    private static final Logger log = Logger.getLogger(ByteStringifier.class);
+    private static final Logger log = LogManager.getLogger(ByteStringifier.class);
 
     @Override
     public String toString(Byte aByte) {

--- a/serialization/src/main/java/com/indeed/util/serialization/CharSerializer.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/CharSerializer.java
@@ -1,6 +1,7 @@
 package com.indeed.util.serialization;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -11,7 +12,7 @@ import java.io.IOException;
  */
 public final class CharSerializer implements Serializer<Character> {
 
-    private static final Logger log = Logger.getLogger(CharSerializer.class);
+    private static final Logger log = LogManager.getLogger(CharSerializer.class);
 
     @Override
     public void write(final Character val, final DataOutput out) throws IOException {

--- a/serialization/src/main/java/com/indeed/util/serialization/CharStringifier.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/CharStringifier.java
@@ -1,12 +1,13 @@
 package com.indeed.util.serialization;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * @author jplaisance
  */
 public final class CharStringifier implements Stringifier<Character>{
-    private static final Logger log = Logger.getLogger(CharStringifier.class);
+    private static final Logger log = LogManager.getLogger(CharStringifier.class);
 
     @Override
     public String toString(Character character) {

--- a/serialization/src/main/java/com/indeed/util/serialization/ClassStringifier.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/ClassStringifier.java
@@ -1,12 +1,13 @@
 package com.indeed.util.serialization;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * @author jplaisance
  */
 public final class ClassStringifier implements Stringifier<Class> {
-    private static final Logger log = Logger.getLogger(ClassStringifier.class);
+    private static final Logger log = LogManager.getLogger(ClassStringifier.class);
 
     @Override
     public String toString(Class aClass) {

--- a/serialization/src/main/java/com/indeed/util/serialization/CollectionSuppliers.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/CollectionSuppliers.java
@@ -4,7 +4,8 @@ import com.google.common.base.Supplier;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.HashMap;
 import java.util.List;
@@ -16,7 +17,7 @@ import java.util.TreeMap;
  * @author jplaisance
  */
 public final class CollectionSuppliers {
-    private static final Logger log = Logger.getLogger(CollectionSuppliers.class);
+    private static final Logger log = LogManager.getLogger(CollectionSuppliers.class);
 
     public static class HashMapSupplier<K, V> implements Supplier<Map<K, V>> {
         @Override

--- a/serialization/src/main/java/com/indeed/util/serialization/DoubleSerializer.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/DoubleSerializer.java
@@ -1,6 +1,7 @@
 package com.indeed.util.serialization;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -11,7 +12,7 @@ import java.io.IOException;
  */
 public final class DoubleSerializer implements Serializer<Double> {
 
-    private static final Logger log = Logger.getLogger(DoubleSerializer.class);
+    private static final Logger log = LogManager.getLogger(DoubleSerializer.class);
 
     @Override
     public void write(final Double val, final DataOutput out) throws IOException {

--- a/serialization/src/main/java/com/indeed/util/serialization/DoubleStringifier.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/DoubleStringifier.java
@@ -1,12 +1,13 @@
 package com.indeed.util.serialization;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * @author jplaisance
  */
 public final class DoubleStringifier implements Stringifier<Double> {
-    private static final Logger log = Logger.getLogger(DoubleStringifier.class);
+    private static final Logger log = LogManager.getLogger(DoubleStringifier.class);
 
     @Override
     public String toString(Double aDouble) {

--- a/serialization/src/main/java/com/indeed/util/serialization/FloatSerializer.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/FloatSerializer.java
@@ -1,6 +1,7 @@
 package com.indeed.util.serialization;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -11,7 +12,7 @@ import java.io.IOException;
  */
 public final class FloatSerializer implements Serializer<Float> {
 
-    private static final Logger log = Logger.getLogger(FloatSerializer.class);
+    private static final Logger log = LogManager.getLogger(FloatSerializer.class);
 
     @Override
     public void write(final Float val, final DataOutput out) throws IOException {

--- a/serialization/src/main/java/com/indeed/util/serialization/FloatStringifier.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/FloatStringifier.java
@@ -1,12 +1,13 @@
 package com.indeed.util.serialization;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * @author jplaisance
  */
 public final class FloatStringifier implements Stringifier<Float> {
-    private static final Logger log = Logger.getLogger(FloatStringifier.class);
+    private static final Logger log = LogManager.getLogger(FloatStringifier.class);
 
     @Override
     public String toString(Float aFloat) {

--- a/serialization/src/main/java/com/indeed/util/serialization/IntSerializer.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/IntSerializer.java
@@ -1,6 +1,7 @@
 package com.indeed.util.serialization;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -11,7 +12,7 @@ import java.io.IOException;
  */
 public final class IntSerializer implements Serializer<Integer> {
 
-    private static final Logger log = Logger.getLogger(IntSerializer.class);
+    private static final Logger log = LogManager.getLogger(IntSerializer.class);
 
     @Override
     public void write(Integer i, final DataOutput out) throws IOException {

--- a/serialization/src/main/java/com/indeed/util/serialization/LengthVIntSerializer.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/LengthVIntSerializer.java
@@ -1,6 +1,7 @@
 package com.indeed.util.serialization;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -12,7 +13,7 @@ import java.io.IOException;
  * @author jplaisance
  */
 public final class LengthVIntSerializer implements Serializer<Integer> {
-    private static final Logger log = Logger.getLogger(LengthVIntSerializer.class);
+    private static final Logger log = LogManager.getLogger(LengthVIntSerializer.class);
 
     @Override
     public void write(Integer i, DataOutput out) throws IOException {

--- a/serialization/src/main/java/com/indeed/util/serialization/LongSerializer.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/LongSerializer.java
@@ -1,6 +1,7 @@
 package com.indeed.util.serialization;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -11,7 +12,7 @@ import java.io.IOException;
  */
 public final class LongSerializer implements Serializer<Long> {
 
-    private static final Logger log = Logger.getLogger(LongSerializer.class);
+    private static final Logger log = LogManager.getLogger(LongSerializer.class);
 
     @Override
     public void write(final Long l, final DataOutput out) throws IOException {

--- a/serialization/src/main/java/com/indeed/util/serialization/LongStringifier.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/LongStringifier.java
@@ -1,13 +1,14 @@
 package com.indeed.util.serialization;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * @author jplaisance
  */
 public final class LongStringifier implements Stringifier<Long> {
 
-    private static final Logger log = Logger.getLogger(LongStringifier.class);
+    private static final Logger log = LogManager.getLogger(LongStringifier.class);
 
     @Override
     public String toString(final Long l) {

--- a/serialization/src/main/java/com/indeed/util/serialization/NewInstanceStringifier.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/NewInstanceStringifier.java
@@ -1,12 +1,13 @@
 package com.indeed.util.serialization;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * @author jplaisance
  */
 public final class NewInstanceStringifier implements Stringifier<Object> {
-    private static final Logger log = Logger.getLogger(NewInstanceStringifier.class);
+    private static final Logger log = LogManager.getLogger(NewInstanceStringifier.class);
 
     @Override
     public String toString(Object o) {

--- a/serialization/src/main/java/com/indeed/util/serialization/ShortSerializer.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/ShortSerializer.java
@@ -1,6 +1,7 @@
 package com.indeed.util.serialization;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -11,7 +12,7 @@ import java.io.IOException;
  */
 public final class ShortSerializer implements Serializer<Short> {
 
-    private static final Logger log = Logger.getLogger(ShortSerializer.class);
+    private static final Logger log = LogManager.getLogger(ShortSerializer.class);
 
     @Override
     public void write(final Short val, final DataOutput out) throws IOException {

--- a/serialization/src/main/java/com/indeed/util/serialization/ShortStringifier.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/ShortStringifier.java
@@ -1,12 +1,13 @@
 package com.indeed.util.serialization;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * @author jplaisance
  */
 public final class ShortStringifier implements Stringifier<Short> {
-    private static final Logger log = Logger.getLogger(ShortStringifier.class);
+    private static final Logger log = LogManager.getLogger(ShortStringifier.class);
 
     @Override
     public String toString(Short aShort) {

--- a/serialization/src/main/java/com/indeed/util/serialization/StringSerializer.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/StringSerializer.java
@@ -1,7 +1,8 @@
 package com.indeed.util.serialization;
 
 import com.google.common.base.Charsets;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -12,7 +13,7 @@ import java.io.IOException;
  */
 public final class StringSerializer implements Serializer<String> {
 
-    private static final Logger log = Logger.getLogger(StringSerializer.class);
+    private static final Logger log = LogManager.getLogger(StringSerializer.class);
 
     private static final LengthVIntSerializer lengthSerializer = new LengthVIntSerializer();
 

--- a/serialization/src/main/java/com/indeed/util/serialization/StringStringifier.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/StringStringifier.java
@@ -1,12 +1,13 @@
 package com.indeed.util.serialization;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * @author jplaisance
  */
 public final class StringStringifier implements Stringifier<String> {
-    private static final Logger log = Logger.getLogger(StringStringifier.class);
+    private static final Logger log = LogManager.getLogger(StringStringifier.class);
 
     @Override
     public String toString(String s) {

--- a/serialization/src/main/java/com/indeed/util/serialization/VarULongSerializer.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/VarULongSerializer.java
@@ -1,6 +1,7 @@
 package com.indeed.util.serialization;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -10,7 +11,7 @@ import java.io.IOException;
  * @author jplaisance
  */
 public final class VarULongSerializer implements Serializer<Long> {
-    private static final Logger log = Logger.getLogger(VarULongSerializer.class);
+    private static final Logger log = LogManager.getLogger(VarULongSerializer.class);
 
     private static final long MAX_31 = 0x7FFFFFFF;
     public static final int HIGH_BIT = 1 << 31;

--- a/serialization/src/main/java/com/indeed/util/serialization/array/BooleanArraySerializer.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/array/BooleanArraySerializer.java
@@ -2,7 +2,8 @@ package com.indeed.util.serialization.array;
 
 import com.indeed.util.serialization.LengthVIntSerializer;
 import com.indeed.util.serialization.Serializer;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -12,7 +13,7 @@ import java.io.IOException;
  * @author jplaisance
  */
 public final class BooleanArraySerializer implements Serializer<boolean[]> {
-    private static final Logger log = Logger.getLogger(BooleanArraySerializer.class);
+    private static final Logger log = LogManager.getLogger(BooleanArraySerializer.class);
 
     private static final LengthVIntSerializer lengthSerializer = new LengthVIntSerializer();
 

--- a/serialization/src/main/java/com/indeed/util/serialization/array/BooleanArrayStringifier.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/array/BooleanArrayStringifier.java
@@ -4,7 +4,8 @@ import com.google.common.base.CharMatcher;
 import com.google.common.collect.Lists;
 import com.indeed.util.serialization.Stringifier;
 import com.indeed.util.serialization.splitter.EscapeAwareSplitter;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -14,7 +15,7 @@ import java.util.List;
  * @author jplaisance
  */
 public final class BooleanArrayStringifier implements Stringifier<boolean[]>{
-    private static final Logger log = Logger.getLogger(BooleanArrayStringifier.class);
+    private static final Logger log = LogManager.getLogger(BooleanArrayStringifier.class);
 
     @Override
     public String toString(boolean[] booleans) {

--- a/serialization/src/main/java/com/indeed/util/serialization/array/ByteArraySerializer.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/array/ByteArraySerializer.java
@@ -2,7 +2,8 @@ package com.indeed.util.serialization.array;
 
 import com.indeed.util.serialization.LengthVIntSerializer;
 import com.indeed.util.serialization.Serializer;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -12,7 +13,7 @@ import java.io.IOException;
  * @author jplaisance
  */
 public final class ByteArraySerializer implements Serializer<byte[]> {
-    private static final Logger log = Logger.getLogger(ByteArraySerializer.class);
+    private static final Logger log = LogManager.getLogger(ByteArraySerializer.class);
 
     private static final LengthVIntSerializer lengthSerializer = new LengthVIntSerializer();
 

--- a/serialization/src/main/java/com/indeed/util/serialization/array/ByteArrayStringifier.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/array/ByteArrayStringifier.java
@@ -4,7 +4,8 @@ import com.google.common.base.CharMatcher;
 import com.google.common.collect.Lists;
 import com.indeed.util.serialization.Stringifier;
 import com.indeed.util.serialization.splitter.EscapeAwareSplitter;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -14,7 +15,7 @@ import java.util.List;
  * @author jplaisance
  */
 public final class ByteArrayStringifier implements Stringifier<byte[]> {
-    private static final Logger log = Logger.getLogger(ByteArrayStringifier.class);
+    private static final Logger log = LogManager.getLogger(ByteArrayStringifier.class);
 
     @Override
     public String toString(byte[] bytes) {

--- a/serialization/src/main/java/com/indeed/util/serialization/array/CharArraySerializer.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/array/CharArraySerializer.java
@@ -2,7 +2,8 @@ package com.indeed.util.serialization.array;
 
 import com.indeed.util.serialization.LengthVIntSerializer;
 import com.indeed.util.serialization.Serializer;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -12,7 +13,7 @@ import java.io.IOException;
  * @author jplaisance
  */
 public final class CharArraySerializer implements Serializer<char[]> {
-    private static final Logger log = Logger.getLogger(CharArraySerializer.class);
+    private static final Logger log = LogManager.getLogger(CharArraySerializer.class);
     
     private static final LengthVIntSerializer lengthSerializer = new LengthVIntSerializer();
 

--- a/serialization/src/main/java/com/indeed/util/serialization/array/CharArrayStringifier.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/array/CharArrayStringifier.java
@@ -4,7 +4,8 @@ import com.google.common.base.CharMatcher;
 import com.google.common.collect.Lists;
 import com.indeed.util.serialization.Stringifier;
 import com.indeed.util.serialization.splitter.EscapeAwareSplitter;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -14,7 +15,7 @@ import java.util.List;
  * @author jplaisance
  */
 public final class CharArrayStringifier implements Stringifier<char[]> {
-    private static final Logger log = Logger.getLogger(CharArrayStringifier.class);
+    private static final Logger log = LogManager.getLogger(CharArrayStringifier.class);
 
     @Override
     public String toString(char[] chars) {

--- a/serialization/src/main/java/com/indeed/util/serialization/array/DoubleArraySerializer.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/array/DoubleArraySerializer.java
@@ -2,7 +2,8 @@ package com.indeed.util.serialization.array;
 
 import com.indeed.util.serialization.LengthVIntSerializer;
 import com.indeed.util.serialization.Serializer;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -12,7 +13,7 @@ import java.io.IOException;
  * @author jplaisance
  */
 public final class DoubleArraySerializer implements Serializer<double[]> {
-    private static final Logger log = Logger.getLogger(DoubleArraySerializer.class);
+    private static final Logger log = LogManager.getLogger(DoubleArraySerializer.class);
 
     private static final LengthVIntSerializer lengthSerializer = new LengthVIntSerializer();
 

--- a/serialization/src/main/java/com/indeed/util/serialization/array/DoubleArrayStringifier.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/array/DoubleArrayStringifier.java
@@ -4,7 +4,8 @@ import com.google.common.base.CharMatcher;
 import com.google.common.collect.Lists;
 import com.indeed.util.serialization.Stringifier;
 import com.indeed.util.serialization.splitter.EscapeAwareSplitter;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -14,7 +15,7 @@ import java.util.List;
  * @author jplaisance
  */
 public final class DoubleArrayStringifier implements Stringifier<double[]> {
-    private static final Logger log = Logger.getLogger(DoubleArrayStringifier.class);
+    private static final Logger log = LogManager.getLogger(DoubleArrayStringifier.class);
 
     @Override
     public String toString(double[] doubles) {

--- a/serialization/src/main/java/com/indeed/util/serialization/array/FloatArraySerializer.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/array/FloatArraySerializer.java
@@ -2,7 +2,8 @@ package com.indeed.util.serialization.array;
 
 import com.indeed.util.serialization.LengthVIntSerializer;
 import com.indeed.util.serialization.Serializer;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -12,7 +13,7 @@ import java.io.IOException;
  * @author jplaisance
  */
 public final class FloatArraySerializer implements Serializer<float[]> {
-    private static final Logger log = Logger.getLogger(FloatArraySerializer.class);
+    private static final Logger log = LogManager.getLogger(FloatArraySerializer.class);
 
     private static final LengthVIntSerializer lengthSerializer = new LengthVIntSerializer();
 

--- a/serialization/src/main/java/com/indeed/util/serialization/array/FloatArrayStringifier.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/array/FloatArrayStringifier.java
@@ -4,7 +4,8 @@ import com.google.common.base.CharMatcher;
 import com.google.common.collect.Lists;
 import com.indeed.util.serialization.Stringifier;
 import com.indeed.util.serialization.splitter.EscapeAwareSplitter;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -14,7 +15,7 @@ import java.util.List;
  * @author jplaisance
  */
 public final class FloatArrayStringifier implements Stringifier<float[]> {
-    private static final Logger log = Logger.getLogger(FloatArrayStringifier.class);
+    private static final Logger log = LogManager.getLogger(FloatArrayStringifier.class);
 
     @Override
     public String toString(float[] floats) {

--- a/serialization/src/main/java/com/indeed/util/serialization/array/IntArraySerializer.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/array/IntArraySerializer.java
@@ -2,7 +2,8 @@ package com.indeed.util.serialization.array;
 
 import com.indeed.util.serialization.LengthVIntSerializer;
 import com.indeed.util.serialization.Serializer;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -12,7 +13,7 @@ import java.io.IOException;
  * @author jplaisance
  */
 public final class IntArraySerializer implements Serializer<int[]> {
-    private static final Logger log = Logger.getLogger(IntArraySerializer.class);
+    private static final Logger log = LogManager.getLogger(IntArraySerializer.class);
 
     private static final LengthVIntSerializer lengthSerializer = new LengthVIntSerializer();
 

--- a/serialization/src/main/java/com/indeed/util/serialization/array/IntArrayStringifier.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/array/IntArrayStringifier.java
@@ -4,7 +4,8 @@ import com.google.common.base.CharMatcher;
 import com.google.common.collect.Lists;
 import com.indeed.util.serialization.Stringifier;
 import com.indeed.util.serialization.splitter.EscapeAwareSplitter;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -14,7 +15,7 @@ import java.util.List;
  * @author jplaisance
  */
 public final class IntArrayStringifier implements Stringifier<int[]> {
-    private static final Logger log = Logger.getLogger(IntArrayStringifier.class);
+    private static final Logger log = LogManager.getLogger(IntArrayStringifier.class);
 
     @Override
     public String toString(int[] ints) {

--- a/serialization/src/main/java/com/indeed/util/serialization/array/LongArraySerializer.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/array/LongArraySerializer.java
@@ -2,7 +2,8 @@ package com.indeed.util.serialization.array;
 
 import com.indeed.util.serialization.LengthVIntSerializer;
 import com.indeed.util.serialization.Serializer;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -12,7 +13,7 @@ import java.io.IOException;
  * @author jplaisance
  */
 public final class LongArraySerializer implements Serializer<long[]> {
-    private static final Logger log = Logger.getLogger(LongArraySerializer.class);
+    private static final Logger log = LogManager.getLogger(LongArraySerializer.class);
 
     private static final LengthVIntSerializer lengthSerializer = new LengthVIntSerializer();
 

--- a/serialization/src/main/java/com/indeed/util/serialization/array/LongArrayStringifier.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/array/LongArrayStringifier.java
@@ -4,7 +4,8 @@ import com.google.common.base.CharMatcher;
 import com.google.common.collect.Lists;
 import com.indeed.util.serialization.Stringifier;
 import com.indeed.util.serialization.splitter.EscapeAwareSplitter;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -14,7 +15,7 @@ import java.util.List;
  * @author jplaisance
  */
 public final class LongArrayStringifier implements Stringifier<long[]> {
-    private static final Logger log = Logger.getLogger(LongArrayStringifier.class);
+    private static final Logger log = LogManager.getLogger(LongArrayStringifier.class);
 
     @Override
     public String toString(long[] longs) {

--- a/serialization/src/main/java/com/indeed/util/serialization/array/ObjectArraySerializer.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/array/ObjectArraySerializer.java
@@ -2,7 +2,8 @@ package com.indeed.util.serialization.array;
 
 import com.indeed.util.serialization.LengthVIntSerializer;
 import com.indeed.util.serialization.Serializer;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -13,7 +14,7 @@ import java.lang.reflect.Array;
  * @author jplaisance
  */
 public final class ObjectArraySerializer<E> implements Serializer<E[]> {
-    private static final Logger log = Logger.getLogger(ObjectArraySerializer.class);
+    private static final Logger log = LogManager.getLogger(ObjectArraySerializer.class);
 
     private static final LengthVIntSerializer lengthSerializer = new LengthVIntSerializer();
 

--- a/serialization/src/main/java/com/indeed/util/serialization/array/ObjectArrayStringifier.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/array/ObjectArrayStringifier.java
@@ -2,7 +2,8 @@ package com.indeed.util.serialization.array;
 
 import com.indeed.util.serialization.Stringifier;
 import com.indeed.util.serialization.list.ListStringifier;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.lang.reflect.Array;
 import java.util.Arrays;
@@ -12,7 +13,7 @@ import java.util.List;
 * @author jplaisance
 */
 public final class ObjectArrayStringifier<E> implements Stringifier<E[]> {
-    private static final Logger log = Logger.getLogger(ObjectArrayStringifier.class);
+    private static final Logger log = LogManager.getLogger(ObjectArrayStringifier.class);
 
     private final ListStringifier<E> listStringifier;
     private final Class<E> type;

--- a/serialization/src/main/java/com/indeed/util/serialization/array/ShortArraySerializer.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/array/ShortArraySerializer.java
@@ -2,7 +2,8 @@ package com.indeed.util.serialization.array;
 
 import com.indeed.util.serialization.LengthVIntSerializer;
 import com.indeed.util.serialization.Serializer;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -12,7 +13,7 @@ import java.io.IOException;
  * @author jplaisance
  */
 public final class ShortArraySerializer implements Serializer<short[]> {
-    private static final Logger log = Logger.getLogger(ShortArraySerializer.class);
+    private static final Logger log = LogManager.getLogger(ShortArraySerializer.class);
 
     private static final LengthVIntSerializer lengthSerializer = new LengthVIntSerializer();
 

--- a/serialization/src/main/java/com/indeed/util/serialization/array/ShortArrayStringifier.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/array/ShortArrayStringifier.java
@@ -4,7 +4,8 @@ import com.google.common.base.CharMatcher;
 import com.google.common.collect.Lists;
 import com.indeed.util.serialization.Stringifier;
 import com.indeed.util.serialization.splitter.EscapeAwareSplitter;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -14,7 +15,7 @@ import java.util.List;
  * @author jplaisance
  */
 public final class ShortArrayStringifier implements Stringifier<short[]> {
-    private static final Logger log = Logger.getLogger(ShortArrayStringifier.class);
+    private static final Logger log = LogManager.getLogger(ShortArrayStringifier.class);
 
     @Override
     public String toString(short[] shorts) {

--- a/serialization/src/main/java/com/indeed/util/serialization/list/ListSerializer.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/list/ListSerializer.java
@@ -4,7 +4,8 @@ import com.google.common.base.Supplier;
 import com.indeed.util.serialization.CollectionSuppliers;
 import com.indeed.util.serialization.LengthVIntSerializer;
 import com.indeed.util.serialization.Serializer;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -15,7 +16,7 @@ import java.util.List;
  * @author jplaisance
  */
 public final class ListSerializer<T> implements Serializer<List<T>> {
-    private static final Logger log = Logger.getLogger(ListSerializer.class);
+    private static final Logger log = LogManager.getLogger(ListSerializer.class);
 
     private static final LengthVIntSerializer lengthSerializer = new LengthVIntSerializer();
 

--- a/serialization/src/main/java/com/indeed/util/serialization/list/ListStringifier.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/list/ListStringifier.java
@@ -6,7 +6,8 @@ import com.indeed.util.serialization.CollectionSuppliers;
 import com.indeed.util.serialization.Stringifier;
 import com.indeed.util.serialization.splitter.EscapeAwareSplitter;
 import org.apache.commons.lang.StringEscapeUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.Iterator;
 import java.util.List;
@@ -15,7 +16,7 @@ import java.util.List;
  * @author jplaisance
  */
 public final class ListStringifier<E> implements Stringifier<List<E>> {
-    private static final Logger log = Logger.getLogger(ListStringifier.class);
+    private static final Logger log = LogManager.getLogger(ListStringifier.class);
 
     private static final EscapeAwareSplitter splitter = new EscapeAwareSplitter(CharMatcher.whitespace().or(CharMatcher.is(',')), EscapeAwareSplitter.ESCAPE_JAVA_LEXER_SUPPLIER);
     

--- a/serialization/src/main/java/com/indeed/util/serialization/map/MapSerializer.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/map/MapSerializer.java
@@ -4,7 +4,8 @@ import com.google.common.base.Supplier;
 import com.indeed.util.serialization.CollectionSuppliers;
 import com.indeed.util.serialization.LengthVIntSerializer;
 import com.indeed.util.serialization.Serializer;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -15,7 +16,7 @@ import java.util.Map;
  * @author jplaisance
  */
 public final class MapSerializer<K,V> implements Serializer<Map<K,V>> {
-    private static final Logger log = Logger.getLogger(MapSerializer.class);
+    private static final Logger log = LogManager.getLogger(MapSerializer.class);
 
     private static final LengthVIntSerializer lengthSerializer = new LengthVIntSerializer();
     

--- a/serialization/src/main/java/com/indeed/util/serialization/map/MapStringifier.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/map/MapStringifier.java
@@ -6,7 +6,8 @@ import com.indeed.util.serialization.CollectionSuppliers;
 import com.indeed.util.serialization.Stringifier;
 import com.indeed.util.serialization.splitter.EscapeAwareSplitter;
 import org.apache.commons.lang.StringEscapeUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -15,7 +16,7 @@ import java.util.Map;
  * @author jplaisance
  */
 public final class MapStringifier<K,V> implements Stringifier<Map<K, V>> {
-    private static final Logger log = Logger.getLogger(MapStringifier.class);
+    private static final Logger log = LogManager.getLogger(MapStringifier.class);
 
     private static final EscapeAwareSplitter splitter = new EscapeAwareSplitter(CharMatcher.whitespace().or(CharMatcher.anyOf(",=")), EscapeAwareSplitter.ESCAPE_JAVA_LEXER_SUPPLIER);
 

--- a/serialization/src/main/java/com/indeed/util/serialization/map/NavigableMapSerializer.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/map/NavigableMapSerializer.java
@@ -3,7 +3,8 @@ package com.indeed.util.serialization.map;
 import com.google.common.base.Supplier;
 import com.indeed.util.serialization.CollectionSuppliers;
 import com.indeed.util.serialization.Serializer;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -14,7 +15,7 @@ import java.util.NavigableMap;
  * @author jplaisance
  */
 public final class NavigableMapSerializer<K,V> implements Serializer<NavigableMap<K,V>> {
-    private static final Logger log = Logger.getLogger(NavigableMapSerializer.class);
+    private static final Logger log = LogManager.getLogger(NavigableMapSerializer.class);
 
     public static <K extends Comparable,V> NavigableMapSerializer<K,V> treeMapSerializer(Serializer<K> keySerializer, Serializer<V> valueSerializer) {
         return new NavigableMapSerializer<K, V>(new CollectionSuppliers.TreeMapSupplier<K, V>(), keySerializer, valueSerializer);

--- a/serialization/src/main/java/com/indeed/util/serialization/set/SetSerializer.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/set/SetSerializer.java
@@ -4,7 +4,8 @@ import com.google.common.base.Supplier;
 import com.indeed.util.serialization.CollectionSuppliers;
 import com.indeed.util.serialization.LengthVIntSerializer;
 import com.indeed.util.serialization.Serializer;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.DataInput;
 import java.io.DataOutput;
@@ -15,7 +16,7 @@ import java.util.Set;
  * @author jplaisance
  */
 public final class SetSerializer<E> implements Serializer<Set<E>> {
-    private static final Logger log = Logger.getLogger(SetSerializer.class);
+    private static final Logger log = LogManager.getLogger(SetSerializer.class);
 
     private static final LengthVIntSerializer lengthSerializer = new LengthVIntSerializer();
     

--- a/serialization/src/main/java/com/indeed/util/serialization/splitter/EscapeAwareSplitter.java
+++ b/serialization/src/main/java/com/indeed/util/serialization/splitter/EscapeAwareSplitter.java
@@ -4,7 +4,8 @@ import com.google.common.base.CharMatcher;
 import com.google.common.base.Supplier;
 import com.google.common.collect.AbstractIterator;
 import org.apache.commons.lang.StringEscapeUtils;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.Iterator;
 
@@ -12,7 +13,7 @@ import java.util.Iterator;
  * @author jplaisance
  */
 public final class EscapeAwareSplitter {
-    private static final Logger log = Logger.getLogger(EscapeAwareSplitter.class);
+    private static final Logger log = LogManager.getLogger(EscapeAwareSplitter.class);
     
     public static final Supplier<Lexer> NO_ESCAPE_LEXER_SUPPLIER = new Supplier<Lexer>() {
         @Override

--- a/serialization/src/test/java/com/indeed/util/serialization/TestVarULongSerializer.java
+++ b/serialization/src/test/java/com/indeed/util/serialization/TestVarULongSerializer.java
@@ -3,7 +3,8 @@ package com.indeed.util.serialization;
 import com.google.common.io.ByteArrayDataOutput;
 import com.google.common.io.ByteStreams;
 import junit.framework.TestCase;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.IOException;
 
@@ -11,7 +12,7 @@ import java.io.IOException;
  * @author jplaisance
  */
 public final class TestVarULongSerializer extends TestCase {
-    private static final Logger log = Logger.getLogger(TestVarULongSerializer.class);
+    private static final Logger log = LogManager.getLogger(TestVarULongSerializer.class);
 
     public void testStuff() throws IOException {
         testLong(0);

--- a/urlparsing/build.gradle
+++ b/urlparsing/build.gradle
@@ -5,7 +5,8 @@ plugins {
 ext['indeed.publish.name'] = 'util-urlparsing'
 
 dependencies {
-    compile library('log4j:log4j')
+    compile library('org.apache.logging.log4j:log4j-core')
+    compile library('org.apache.logging.log4j:log4j-api')
     compile 'it.unimi.dsi:fastutil:6.2.2'
     compile library('com.google.guava:guava')
 

--- a/urlparsing/src/test/java/com/indeed/util/urlparsing/benchmark/StringSplitKeyValueParser.java
+++ b/urlparsing/src/test/java/com/indeed/util/urlparsing/benchmark/StringSplitKeyValueParser.java
@@ -1,6 +1,7 @@
 package com.indeed.util.urlparsing.benchmark;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -12,7 +13,7 @@ import java.util.Map;
  */
 public class StringSplitKeyValueParser implements KeyValueParser {
 
-    private static final Logger LOGGER = Logger.getLogger(StringSplitKeyValueParser.class);
+    private static final Logger LOGGER = LogManager.getLogger(StringSplitKeyValueParser.class);
 
     @Override
     public void parse(String log) {

--- a/util-core/build.gradle
+++ b/util-core/build.gradle
@@ -7,7 +7,8 @@ ext['indeed.publish.name'] = 'util-core'
 dependencies {
     compile project(':varexport')
     compile library('com.google.guava:guava')
-    compile library('log4j:log4j')
+    compile library('org.apache.logging.log4j:log4j-core')
+    compile library('org.apache.logging.log4j:log4j-api')
 
     compileOnly library('com.google.code.findbugs:jsr305')
     testCompileOnly library('com.google.code.findbugs:jsr305')

--- a/util-core/src/main/java/com/indeed/util/core/DataLoadingRunnable.java
+++ b/util-core/src/main/java/com/indeed/util/core/DataLoadingRunnable.java
@@ -2,7 +2,8 @@
 package com.indeed.util.core;
 
 import com.indeed.util.varexport.VarExporter;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * Runnable implementation of the {@link HasDataLoadingVariables} class that
@@ -11,7 +12,7 @@ import org.apache.log4j.Logger;
  * @author jack@indeed.com (Jack Humphrey)
  */
 public abstract class DataLoadingRunnable extends DataLoadTimer implements HasDataLoadingVariables, Runnable {
-    private static final Logger log = Logger.getLogger(DataLoadingRunnable.class);
+    private static final Logger log = LogManager.getLogger(DataLoadingRunnable.class);
 
     // use this for your implementation of load()
     public enum ReloadState {

--- a/util-core/src/main/java/com/indeed/util/core/DataLoadingTimerTask.java
+++ b/util-core/src/main/java/com/indeed/util/core/DataLoadingTimerTask.java
@@ -2,7 +2,8 @@
 package com.indeed.util.core;
 
 import com.indeed.util.varexport.VarExporter;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.TimerTask;
 
@@ -12,7 +13,7 @@ import java.util.TimerTask;
  * @author jack@indeed.com (Jack Humphrey)
  */
 public abstract class DataLoadingTimerTask extends TimerTask implements HasDataLoadingVariables {
-    private static final Logger log = Logger.getLogger(DataLoadingTimerTask.class);
+    private static final Logger log = LogManager.getLogger(DataLoadingTimerTask.class);
 
     protected DataLoadTimer dataLoadTimer = new DataLoadTimer();
     private String dataVersion;

--- a/util-core/src/main/java/com/indeed/util/core/NativeLibraryUtils.java
+++ b/util-core/src/main/java/com/indeed/util/core/NativeLibraryUtils.java
@@ -2,7 +2,8 @@ package com.indeed.util.core;
 
 import com.google.common.base.Strings;
 import com.google.common.io.ByteStreams;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -15,7 +16,7 @@ import java.io.OutputStream;
  */
 public final class NativeLibraryUtils {
 
-    private static final Logger log = Logger.getLogger(NativeLibraryUtils.class);
+    private static final Logger log = LogManager.getLogger(NativeLibraryUtils.class);
 
     public static void loadLibrary(String name) {
         loadLibrary(name, "");

--- a/util-core/src/main/java/com/indeed/util/core/NetUtils.java
+++ b/util-core/src/main/java/com/indeed/util/core/NetUtils.java
@@ -2,7 +2,8 @@ package com.indeed.util.core;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Strings;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -21,7 +22,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
  *
  */
 public class NetUtils {
-    private static final Logger log = Logger.getLogger(NetUtils.class);
+    private static final Logger log = LogManager.getLogger(NetUtils.class);
     private static volatile Optional<String> OPT_HOSTNAME = Optional.absent();
 
     /**

--- a/util-core/src/main/java/com/indeed/util/core/datastruct/IteratorMultiHeap.java
+++ b/util-core/src/main/java/com/indeed/util/core/datastruct/IteratorMultiHeap.java
@@ -1,6 +1,7 @@
 package com.indeed.util.core.datastruct;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.lang.reflect.Array;
 
@@ -9,7 +10,7 @@ import java.lang.reflect.Array;
  */
 public abstract class IteratorMultiHeap<T> {
 
-    private static final Logger log = Logger.getLogger(IteratorMultiHeap.class);
+    private static final Logger log = LogManager.getLogger(IteratorMultiHeap.class);
 
     private final T[] elements;
 

--- a/util-core/src/main/java/com/indeed/util/core/io/Closeables2.java
+++ b/util-core/src/main/java/com/indeed/util/core/io/Closeables2.java
@@ -3,7 +3,8 @@ package com.indeed.util.core.io;
 import com.google.common.base.Function;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Iterables;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;

--- a/util-core/src/main/java/com/indeed/util/core/nativelibs/NativeLibraryUtils.java
+++ b/util-core/src/main/java/com/indeed/util/core/nativelibs/NativeLibraryUtils.java
@@ -2,7 +2,8 @@ package com.indeed.util.core.nativelibs;
 
 import com.google.common.base.Strings;
 import com.google.common.io.ByteStreams;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -15,7 +16,7 @@ import java.io.OutputStream;
  */
 public final class NativeLibraryUtils {
 
-    private static final Logger log = Logger.getLogger(NativeLibraryUtils.class);
+    private static final Logger log = LogManager.getLogger(NativeLibraryUtils.class);
 
     public static void loadLibrary(String name) {
         loadLibrary(name, "");

--- a/util-core/src/main/java/com/indeed/util/core/reference/AtomicSharedReference.java
+++ b/util-core/src/main/java/com/indeed/util/core/reference/AtomicSharedReference.java
@@ -2,7 +2,8 @@ package com.indeed.util.core.reference;
 
 import com.google.common.base.Function;
 import com.indeed.util.core.io.Closeables2;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import javax.annotation.Nullable;
 import java.io.Closeable;
@@ -19,7 +20,7 @@ import java.io.IOException;
  * @author jplaisance
  */
 public final class AtomicSharedReference<T> {
-    private static final Logger log = Logger.getLogger(AtomicSharedReference.class);
+    private static final Logger log = LogManager.getLogger(AtomicSharedReference.class);
 
     public static <T> AtomicSharedReference<T> create() {
         return new AtomicSharedReference<T>();

--- a/util-core/src/main/java/com/indeed/util/core/reference/ReloadableSharedReference.java
+++ b/util-core/src/main/java/com/indeed/util/core/reference/ReloadableSharedReference.java
@@ -2,7 +2,8 @@ package com.indeed.util.core.reference;
 
 import com.google.common.base.Supplier;
 import com.indeed.util.core.io.Closeables2;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import javax.annotation.Nullable;
 import java.io.Closeable;
@@ -13,7 +14,7 @@ import java.io.IOException;
  */
 public final class ReloadableSharedReference<T, E extends Throwable> {
 
-    private static final Logger log = Logger.getLogger(ReloadableSharedReference.class);
+    private static final Logger log = LogManager.getLogger(ReloadableSharedReference.class);
 
     public static <T extends Closeable, E extends Throwable> ReloadableSharedReference<T, E> create(Loader<T, E> loader) {
         return new ReloadableSharedReference<T, E>(loader, Closer.<T>closeableCloser());

--- a/util-core/src/main/java/com/indeed/util/core/reference/SharedReference.java
+++ b/util-core/src/main/java/com/indeed/util/core/reference/SharedReference.java
@@ -1,6 +1,7 @@
 package com.indeed.util.core.reference;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import javax.annotation.Nullable;
 import java.io.Closeable;
@@ -22,7 +23,7 @@ import java.io.IOException;
  */
 public final class SharedReference<T> implements Closeable {
 
-    private static final Logger log = Logger.getLogger(SharedReference.class);
+    private static final Logger log = LogManager.getLogger(SharedReference.class);
 
     private static final boolean debug = Boolean.getBoolean("com.indeed.common.util.reference.SharedReference.debug");
 

--- a/util-core/src/main/java/com/indeed/util/core/reference/WeakSharedReference.java
+++ b/util-core/src/main/java/com/indeed/util/core/reference/WeakSharedReference.java
@@ -1,13 +1,14 @@
 package com.indeed.util.core.reference;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * @author jplaisance
  */
 public final class WeakSharedReference<T> {
 
-    private static final Logger log = Logger.getLogger(WeakSharedReference.class);
+    private static final Logger log = LogManager.getLogger(WeakSharedReference.class);
 
     public static <T> WeakSharedReference<T> create(SharedReference<T> ref) {
         return new WeakSharedReference<T>(ref);

--- a/util-core/src/main/java/com/indeed/util/core/shell/PosixFileOperations.java
+++ b/util-core/src/main/java/com/indeed/util/core/shell/PosixFileOperations.java
@@ -3,7 +3,8 @@ package com.indeed.util.core.shell;
 import com.google.common.base.Charsets;
 import com.google.common.io.ByteStreams;
 import com.google.common.io.CharStreams;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.io.File;
 import java.io.IOException;
@@ -23,7 +24,7 @@ import java.util.ArrayDeque;
  */
 public final class PosixFileOperations {
 
-    private static final Logger log = Logger.getLogger(PosixFileOperations.class);
+    private static final Logger log = LogManager.getLogger(PosixFileOperations.class);
 
     private static final String separator = System.getProperty("file.separator");
 

--- a/util-core/src/main/java/com/indeed/util/core/threads/LogOnUncaughtExceptionHandler.java
+++ b/util-core/src/main/java/com/indeed/util/core/threads/LogOnUncaughtExceptionHandler.java
@@ -2,7 +2,8 @@ package com.indeed.util.core.threads;
 
 import java.lang.Thread.UncaughtExceptionHandler;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 public class LogOnUncaughtExceptionHandler implements UncaughtExceptionHandler {
     private final Logger logger;

--- a/util-core/src/main/java/com/indeed/util/core/threads/NamedThreadFactory.java
+++ b/util-core/src/main/java/com/indeed/util/core/threads/NamedThreadFactory.java
@@ -4,7 +4,8 @@ import com.indeed.util.core.threads.LogOnUncaughtExceptionHandler;
 
 import java.util.concurrent.ThreadFactory;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 /**
  * ThreadFactory implementation that creates threads with descriptive names.
@@ -26,7 +27,7 @@ public class NamedThreadFactory implements ThreadFactory {
     }
 
     public NamedThreadFactory(final String threadName, String loggerName){
-        this(threadName, false, Logger.getLogger(loggerName));
+        this(threadName, false, LogManager.getLogger(loggerName));
     }
 
     public NamedThreadFactory(final String threadName, final Logger logger) {
@@ -60,8 +61,8 @@ public class NamedThreadFactory implements ThreadFactory {
         }
         final Class<? extends Runnable> runnableClass = r.getClass();
         if (runnableClass.getPackage().getName().startsWith("com.indeed.")) {
-            return Logger.getLogger(runnableClass);
+            return LogManager.getLogger(runnableClass);
         }
-        return Logger.getLogger(NamedThreadFactory.class);
+        return LogManager.getLogger(NamedThreadFactory.class);
     }
 }

--- a/util-core/src/test/java/com/indeed/util/core/datastruct/TestIteratorMultiHeap.java
+++ b/util-core/src/test/java/com/indeed/util/core/datastruct/TestIteratorMultiHeap.java
@@ -3,7 +3,8 @@ package com.indeed.util.core.datastruct;
 import com.google.common.collect.Lists;
 import com.google.common.primitives.Ints;
 import junit.framework.TestCase;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.util.Comparator;
 import java.util.List;
@@ -15,7 +16,7 @@ import java.util.Random;
  */
 public final class TestIteratorMultiHeap extends TestCase {
 
-    private static final Logger log = Logger.getLogger(TestIteratorMultiHeap.class);
+    private static final Logger log = LogManager.getLogger(TestIteratorMultiHeap.class);
 
     public static final class RandomIntIterator {
 

--- a/varexport/build.gradle
+++ b/varexport/build.gradle
@@ -6,7 +6,8 @@ ext['indeed.publish.name'] = 'util-varexport'
 
 dependencies {
     compile library('com.google.guava:guava')
-    compile library('log4j:log4j')
+    compile library('org.apache.logging.log4j:log4j-core')
+    compile library('org.apache.logging.log4j:log4j-api')
 
     compileOnly library('com.google.code.findbugs:jsr305')
     compileOnly library('org.apache.tomcat:tomcat-servlet-api')

--- a/varexport/src/main/java/com/indeed/util/varexport/VarExporter.java
+++ b/varexport/src/main/java/com/indeed/util/varexport/VarExporter.java
@@ -13,7 +13,8 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Multimaps;
 import com.google.common.collect.Sets;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -33,7 +34,7 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  */
 public class VarExporter implements VariableHost {
 
-    private static Logger log = Logger.getLogger(VarExporter.class);
+    private static Logger log = LogManager.getLogger(VarExporter.class);
 
     @VisibleForTesting
     protected static ManagedVariable<String> startTime = createStartTimeVariable(new Date());

--- a/varexport/src/main/java/com/indeed/util/varexport/servlet/ViewExportedVariablesServlet.java
+++ b/varexport/src/main/java/com/indeed/util/varexport/servlet/ViewExportedVariablesServlet.java
@@ -12,7 +12,8 @@ import com.indeed.util.varexport.VariableVisitor;
 import freemarker.template.Configuration;
 import freemarker.template.DefaultObjectWrapper;
 import freemarker.template.Template;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import javax.servlet.ServletConfig;
 import javax.servlet.ServletContext;
@@ -35,7 +36,7 @@ import java.util.*;
  */
 public class ViewExportedVariablesServlet extends HttpServlet {
 
-    private static final Logger log = Logger.getLogger(ViewExportedVariablesServlet.class);
+    private static final Logger log = LogManager.getLogger(ViewExportedVariablesServlet.class);
 
     private static final Joiner COMMA_JOINER = Joiner.on(',');
 

--- a/varexport/src/test/java/com/indeed/util/varexport/VarExporterTest.java
+++ b/varexport/src/test/java/com/indeed/util/varexport/VarExporterTest.java
@@ -7,9 +7,14 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.indeed.util.varexport.external.PublicClass;
 
-import org.apache.log4j.BasicConfigurator;
-import org.apache.log4j.Level;
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Configurator;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilder;
+import org.apache.logging.log4j.core.config.builder.api.ConfigurationBuilderFactory;
+import org.apache.logging.log4j.core.config.builder.impl.BuiltConfiguration;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Level;
 import org.hamcrest.Matchers;
 import org.junit.After;
 import org.junit.Assert;
@@ -33,6 +38,7 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
+import static org.apache.logging.log4j.core.appender.ConsoleAppender.Target;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -186,9 +192,19 @@ public class VarExporterTest {
 
     @BeforeClass
     public static void initClass() {
-        BasicConfigurator.configure();
-        Logger.getRootLogger().setLevel(Level.ERROR);
-        Logger.getLogger("com.indeed").setLevel(Level.ERROR);
+        ConfigurationBuilder<BuiltConfiguration> builder = ConfigurationBuilderFactory.newConfigurationBuilder();
+        final Configuration config = builder.setStatusLevel(Level.ERROR)
+                                      .setConfigurationName("Indeed Logging")
+                                      .add(builder.newAppender("stderr", "Console")
+                                                  .addAttribute("target", Target.SYSTEM_ERR))
+                                      .add(builder.newAsyncLogger("com.indeed", Level.DEBUG)
+                                                  .add(builder.newAppenderRef("stderr"))
+                                                  .addAttribute("addivity", false))
+                                      .add(builder.newAsyncRootLogger(Level.ERROR)
+                                                  .add(builder.newAppenderRef("stderr"))
+                                                  .addAttribute("additivity", false))
+                                      .build();
+        Configurator.initialize(builder.build());
     }
 
     @After
@@ -587,7 +603,9 @@ public class VarExporterTest {
 
     @Test
     public void testConcreteClassImplementingInterfaceAgain() {
-        Logger.getRootLogger().setLevel(Level.WARN);
+        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        ctx.getConfiguration().getLoggerConfig(LogManager.ROOT_LOGGER_NAME).setLevel(Level.WARN);
+        ctx.updateLoggers(); 
         exporter.export(new ConcreteClassImplementingInterfaceAgain(), "");
         assertEquals("", exporter.getValue("ifcmethod1"));
         assertEquals("yes", exporter.getValue("something#else"));

--- a/zk/src/main/java/com/indeed/util/zookeeper/ZooKeeperConnection.java
+++ b/zk/src/main/java/com/indeed/util/zookeeper/ZooKeeperConnection.java
@@ -1,6 +1,7 @@
 package com.indeed.util.zookeeper;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 import org.apache.zookeeper.AsyncCallback;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.KeeperException;
@@ -21,7 +22,7 @@ import java.util.concurrent.atomic.AtomicReference;
  */
 public final class ZooKeeperConnection {
 
-    private static final Logger log = Logger.getLogger(ZooKeeperConnection.class);
+    private static final Logger log = LogManager.getLogger(ZooKeeperConnection.class);
 
     private ZooKeeper zooKeeper;
 

--- a/zk/src/test/java/com/indeed/util/zookeeper/CommonMethodsTester.java
+++ b/zk/src/test/java/com/indeed/util/zookeeper/CommonMethodsTester.java
@@ -1,6 +1,7 @@
 package com.indeed.util.zookeeper;
 
-import org.apache.log4j.Logger;
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.LogManager;
 
 import java.beans.BeanInfo;
 import java.beans.Introspector;
@@ -11,7 +12,7 @@ import java.lang.reflect.Method;
  * @author jplaisance
  */
 public final class CommonMethodsTester {
-    private static final Logger log = Logger.getLogger(CommonMethodsTester.class);
+    private static final Logger log = LogManager.getLogger(CommonMethodsTester.class);
 
     public static void testObjectMethods(Class c) {
         try {


### PR DESCRIPTION
As the org.apache.logging.log4j:log4j-1.2-api is not declared as a dependency, dependent libraries can still use log4j 1.x and should be able to migrate piecemeal.